### PR TITLE
ユーザ画面に機能を追加

### DIFF
--- a/client/src/pages/User.tsx
+++ b/client/src/pages/User.tsx
@@ -1,15 +1,93 @@
-import { useAPIUserDataContext } from "@/providers/APIUserData";
+import axios from "axios";
+import {useAPIUserDataContext} from "@/providers/APIUserData";
+import {useEffect, useState} from "react";
+import {API_URL} from "@/config";
+import {getAuth} from "firebase/auth";
+import {useNavigate} from "react-router-dom";
+
+const api = axios.create({
+    baseURL: API_URL,
+});
 
 const User = () => {
-  const apiUserData = useAPIUserDataContext();
+    const apiUserData = useAPIUserDataContext();
+    const [editMode, setEditMode] = useState(false);
+    const [name, setName] = useState("");
 
-  return (
-    <>
-      <h1>ユーザーページ</h1>
-      <p>ユーザー名: {apiUserData?.name}</p>
-      <p>ポイント: {apiUserData?.point}</p>
-    </>
-  );
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (apiUserData) {
+            setName(apiUserData.name);
+        }
+    }, [apiUserData]);
+
+    type UpdateUserDataType = {
+        user: {
+            name: string,
+        },
+    };
+    const buildUpdateUserData = (name: string): UpdateUserDataType => {
+        return {
+            user: {
+                name: name,
+            },
+        };
+    }
+    const handleUpdate = async () => {
+        if (!window.confirm('ユーザ情報を更新しますか？')) {
+            return;
+        }
+
+        await api.put(`/api/v1/users/${apiUserData?.id}`, buildUpdateUserData(name))
+            .then(() => {
+                alert('ユーザ情報の更新に成功しました');
+            })
+            .catch(() => {
+                alert('ユーザ情報の更新に失敗しました');
+            });
+    };
+
+    const handleSignOut = async () => {
+        const auth = getAuth();
+        await auth.signOut();
+        navigate('/welcome');
+    };
+
+    return (
+        <div className="p-6 d w-full min-h-[90vh] flex flex-col justify-center items-center">
+            <div className="flex flex-col items-center space-y-4">
+                <h1 className="text-xl font-bold">ユーザーページ</h1>
+                <button
+                    onClick={() => setEditMode(!editMode)}
+                    className={`bg-${editMode ? 'red' : 'blue'}-500 text-white px-4 py-2 rounded-md`}
+                >
+                    {editMode ? 'キャンセル' : '編集'}
+                </button>
+                <label className="text-gray-700">ユーザー名</label>
+                <input
+                    name="name"
+                    type="text"
+                    disabled={!editMode}
+                    className="border-2 border-gray-300 p-2 rounded-md focus:border-blue-500"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                />
+                <p className="text-lg font-semibold">ポイント: {apiUserData?.point}</p>
+                {editMode ? <button
+                        type="button"
+                        onClick={() => handleUpdate()}
+                        className="bg-blue-500 text-white px-4 py-2 rounded-md">更新</button> :
+                    <div>
+                        <button
+                            onClick={() => handleSignOut()}
+                            className="bg-gray-500 text-white px-4 py-2 rounded-md">ログアウト
+                        </button>
+                    </div>
+                }
+            </div>
+        </div>
+    );
 };
 
 export default User;

--- a/client/src/pages/User.tsx
+++ b/client/src/pages/User.tsx
@@ -9,6 +9,9 @@ const api = axios.create({
     baseURL: API_URL,
 });
 
+/**
+ * ユーザページ
+ */
 const User = () => {
     const apiUserData = useAPIUserDataContext();
     const [editMode, setEditMode] = useState(false);
@@ -16,17 +19,21 @@ const User = () => {
 
     const navigate = useNavigate();
 
+    // ユーザデータが取得できたら、名前をセット
     useEffect(() => {
         if (apiUserData) {
             setName(apiUserData.name);
         }
     }, [apiUserData]);
 
+    // ユーザデータ更新APIのリクエストボディの型
     type UpdateUserDataType = {
         user: {
             name: string,
         },
     };
+
+    // ユーザデータ更新APIのリクエストボディを構築
     const buildUpdateUserData = (name: string): UpdateUserDataType => {
         return {
             user: {
@@ -34,6 +41,7 @@ const User = () => {
             },
         };
     }
+    //ユーザデータの更新処理
     const handleUpdate = async () => {
         if (!window.confirm('ユーザ情報を更新しますか？')) {
             return;
@@ -48,6 +56,12 @@ const User = () => {
             });
     };
 
+    // キャンセルボタンを押した時の処理
+    const handleCancel = () => {
+        setName(apiUserData?.name || "");
+    };
+
+    // ログアウト処理
     const handleSignOut = async () => {
         const auth = getAuth();
         await auth.signOut();
@@ -59,7 +73,10 @@ const User = () => {
             <div className="flex flex-col items-center space-y-4">
                 <h1 className="text-xl font-bold">ユーザーページ</h1>
                 <button
-                    onClick={() => setEditMode(!editMode)}
+                    onClick={() => {
+                        editMode && handleCancel();
+                        setEditMode(!editMode);
+                    }}
                     className={`bg-${editMode ? 'red' : 'blue'}-500 text-white px-4 py-2 rounded-md`}
                 >
                     {editMode ? 'キャンセル' : '編集'}

--- a/client/src/pages/User.tsx
+++ b/client/src/pages/User.tsx
@@ -54,6 +54,7 @@ const User = () => {
             .catch(() => {
                 alert('ユーザ情報の更新に失敗しました');
             });
+        setEditMode(false);
     };
 
     // キャンセルボタンを押した時の処理


### PR DESCRIPTION
## 関連

#71 

## 変更の概要


-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

- ユーザ画面でログアウトとユーザネーム変更が行えるように変更した。
## 動作確認
/userにアクセスし、以下の動作を確認した。
- ログアウトボタンを押すと、ログアウトし、welcome画面に遷移する
- 編集ボタンを押すと、ログアウトボタンが消え、編集ボタンがキャンセルボタンに変わる
- キャンセルボタンを押すとユーザデータ欄がもとのユーザネームにリセットされる。
- ユーザ名が実際に更新される
-
## その他
- useAPIUserDataの更新用関数がないため、更新後、新しいユーザデータを取得することができません。